### PR TITLE
fix(builder): exit on fail without awaiting terminate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+- fix: hang on build failure — `await pool.terminate(true)` blocked until sibling workers finished `execSync` (Node cannot force-kill a thread mid-sync spawn). Fail path now fire-and-forgets terminate and `process.exit(1)`, ignores terminate-cascade errors, and throws the real execution error from `runTarget` instead of the `Error` constructor. `noCache` builds also fail closed on worker errors.
 - feat: unified per-project build stats — a `Build — by time` table and a `Largest Artifacts` table (plus a summary block) replace the Missing Projects / Slow Cache Recoveries / Hash Mismatches tables. A new `--stats <silent | default | full>` flag controls the block independently of `--logLevel`. `SKIP` rows are omitted and row counts are not capped; full status counts stay in the summary. Raw output size and file counts are measured only when a project is actually built, so cache-hit rows show `-` in those columns.
 - fix: zip cache recovery hung forever on Node 24 — `extract-zip`'s yauzl@2 read stream stalls mid-entry on deflate entries larger than ~1.4 MB (reproduced byte-for-byte outside Zenith), deadlocking the recovery worker. Zip extraction now uses a small yauzl@3.3.1-based streaming extractor (`extractZipFileToDir`); the `extract-zip` dependency was removed.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jotforminc/zenith",
   "packageManager": "yarn@1.22.21",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "",
   "main": "./build/index.js",
   "files": [

--- a/src/classes/Builder/BuildHelper.ts
+++ b/src/classes/Builder/BuildHelper.ts
@@ -18,6 +18,9 @@ import RemoteCacher from '../Cache/RemoteCacher';
 import { configManagerInstance } from '../../config';
 
 export default class BuildHelper extends WorkerHelper {
+  /** Set once on hard fail so concurrent builders don't race exit / mask the real error. */
+  static exiting = false;
+
   projects : Map<string, Set<string>> = new Map();
 
   command : string;
@@ -30,6 +33,25 @@ export default class BuildHelper extends WorkerHelper {
 
   get projectStats(): Map<string, ProjectRunStats> {
     return this.stats.projectStats;
+  }
+
+  /**
+   * Fail the CLI without awaiting pool.terminate.
+   * Workers blocked in execSync cannot be force-killed until the child exits, so
+   * `await pool.terminate(true)` hangs for the duration of sibling builds.
+   */
+  failFast(buildProject: string, error: Error): never {
+    if (!BuildHelper.exiting) {
+      BuildHelper.exiting = true;
+      Logger.log(3, this.outputColor, 'ERR-B1 :: project: ', buildProject, ' error: ', error.message);
+      void this.pool.terminate(true).catch(() => undefined);
+    }
+    process.exit(1);
+  }
+
+  /** Cascade rejects from force-terminate — park until process.exit from the primary failure. */
+  private static isTerminateCascade(error: Error): boolean {
+    return error.message === 'Worker terminated' || error.message === 'Pool terminated';
   }
 
   compareHash = true;
@@ -223,7 +245,7 @@ export default class BuildHelper extends WorkerHelper {
   async runTarget(buildPath: string, script: string, hash: string, root: string, outputs: Array<string>, buildProject: string, requiredFiles?: string[]): Promise<void> {
     const execution = await this.execute(buildPath, script, hash, root, outputs, buildProject, requiredFiles);
     if (execution instanceof Error) {
-      throw Error;
+      throw execution;
     }
     const { output, execTime, metrics } = execution;
     if (!isCommandDummy(buildPath, script)) {
@@ -278,9 +300,10 @@ export default class BuildHelper extends WorkerHelper {
       }
       if (this.noCache) {
         const execution = await this.execute(buildPath, script, '', root, outputs, buildProject, requiredFiles, this.noCache);
-        if (!(execution instanceof Error)) {
-          this.recordProjectStats(buildProject, { status: 'BUILT', execTime: execution.execTime, metrics: execution.metrics });
+        if (execution instanceof Error) {
+          throw execution;
         }
+        this.recordProjectStats(buildProject, { status: 'BUILT', execTime: execution.execTime, metrics: execution.metrics });
         await this.buildResolver(buildProject);
         return;
       }
@@ -309,9 +332,12 @@ export default class BuildHelper extends WorkerHelper {
       await this.buildResolver(buildProject);
     } catch (error) {
       if (error instanceof Error) {
-        Logger.log(3, this.outputColor, 'ERR-B1 :: project: ', buildProject, ' error: ', error.message);
-        await this.pool.terminate(true);
-        throw error;
+        if (BuildHelper.isTerminateCascade(error) || BuildHelper.exiting) {
+          // Sibling workers rejected by force-terminate — wait for primary failFast exit.
+          await new Promise(() => undefined);
+          return;
+        }
+        this.failFast(buildProject, error);
       } else throw new Error('Builder failed.');
     }
   }

--- a/tests/BuildHelperFailFast.spec.js
+++ b/tests/BuildHelperFailFast.spec.js
@@ -1,0 +1,46 @@
+import BuildHelper from '../build/classes/Builder/BuildHelper';
+
+describe('BuildHelper failFast', () => {
+  afterEach(async () => {
+    BuildHelper.exiting = false;
+    jest.restoreAllMocks();
+  });
+
+  test('does not await pool.terminate (avoids hang on execSync workers)', () => {
+    const helper = new BuildHelper('build', '1', false);
+    let terminateSettled = false;
+    helper.pool.terminate = jest.fn(() => new Promise((resolve) => {
+      setTimeout(() => {
+        terminateSettled = true;
+        resolve();
+      }, 5000);
+    }));
+
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit:${code}`);
+    });
+
+    const started = Date.now();
+    expect(() => helper.failFast('@scope/pkg', new Error('build failed'))).toThrow('process.exit:1');
+    expect(Date.now() - started).toBeLessThan(500);
+    expect(terminateSettled).toBe(false);
+    expect(helper.pool.terminate).toHaveBeenCalledWith(true);
+    expect(BuildHelper.exiting).toBe(true);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    // Prevent the slow terminate promise from keeping Jest open.
+    helper.pool.terminate = () => Promise.resolve();
+  });
+
+  test('second failFast still exits without awaiting terminate', () => {
+    const helper = new BuildHelper('build', '1', false);
+    BuildHelper.exiting = true;
+    helper.pool.terminate = jest.fn(() => new Promise(() => undefined));
+    jest.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit:${code}`);
+    });
+
+    expect(() => helper.failFast('@scope/other', new Error('Worker terminated'))).toThrow('process.exit:1');
+    expect(helper.pool.terminate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- On project build failure, Zenith no longer `await`s `pool.terminate(true)`. Workers blocked in `execSync` cannot be force-killed until the child exits, so that await hung the CLI for the duration of sibling builds (seen as a hang on fail in frontend CI).
- Fail path now fire-and-forgets terminate and calls `process.exit(1)` (same idea as `SingleBuilder`), ignores `Worker terminated` / `Pool terminated` cascade rejects, and fixes `runTarget` throwing the `Error` constructor instead of the execution error. `noCache` builds also fail closed on worker errors.

## Test plan
- [x] `yarn test --testPathPatterns=BuildHelper` (includes new `BuildHelperFailFast` specs)
- [ ] From frontend: `env CACHE_TYPE=local ZENITH_CONFIG_PATH="zenith.js" pnpm zenith --target=build --project=all -np -sp -sd -la` against a linked/local zenith build — should exit promptly on the known module error instead of hanging, without a trailing `Worker terminated` crash replacing the real failure


Made with [Cursor](https://cursor.com)