### PR TITLE
fix: report real command errors instead of worker termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ---
 
+## [v3.7.0] - 2026-08-21
+
+- fix: a failing target reported `Workerpool Worker terminated Unexpectedly` instead of the actual error. The builder force-killed the pool on the first failure, so workerpool rejected every in-flight task with that message and `Promise.all` surfaced whichever rejection won the race; on top of that the real error was replaced with `Executing worker failed` in `WorkerHelper`, and `runTarget` threw the `Error` constructor rather than an instance. Failures now travel as a structured `ZenithCommandError` (project, script, shell command, cwd, exit code, signal, full stdout and stderr), the pool shuts down gracefully so siblings are not rejected with termination noise, and the run ends with a single failure block and exit code 1. Pool shutdown is memoized because a workerpool `WorkerHandler` holds a single termination callback slot: without it, the concurrent graceful terminates issued by each failing project overwrite each other and every caller but the last waits on a promise that never settles, draining the event loop and exiting 0 with no output at all.
+
+---
+
 ## [v3.1.0] - 2026-05-13
 
 - (`52ab324`) perf(builder): faster cyclic dependency check (memoized reachability, Set-based DFS); tests for explicit two-node cycle and acyclic dummy graph

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jotforminc/zenith",
   "packageManager": "yarn@1.22.21",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "",
   "main": "./build/index.js",
   "files": [

--- a/src/classes/Builder/BuildHelper.ts
+++ b/src/classes/Builder/BuildHelper.ts
@@ -12,6 +12,7 @@ import { buildTimeTable, buildSizeTable } from '../../stats/statsTables';
 import { buildStatsSummary, statsRenderPlan } from '../../stats/statsSummary';
 import StatsAggregator from '../../stats/StatsAggregator';
 import Logger from '../../utils/logger';
+import { ZenithCommandError, toZenithCommandError } from '../../utils/errors';
 import { BuildParams, PackageJsonType, ProjectRunStats } from '../../types/BuildTypes';
 import LocalCacher from '../Cache/LocalCacher';
 import RemoteCacher from '../Cache/RemoteCacher';
@@ -60,11 +61,32 @@ export default class BuildHelper extends WorkerHelper {
 
   outputColor = '';
 
+  /** First real command failure of the run; siblings must not overwrite it. */
+  failure: ZenithCommandError | null = null;
+
+  aborted = false;
+
+  private shutdownPromise: Promise<void> | null = null;
+
   constructor(command : string, worker : string, color: boolean) {
     super(command, worker);
     this.command = command;
     this.cacher = CacherFactory.getCacher();
     this.outputColor = color ? `\x1b[3${Math.floor(Math.random() * 6) + 1}m` : '';
+  }
+
+  /**
+   * Graceful pool shutdown, at most once. A forced terminate kills live threads
+   * and workerpool then rejects every in-flight task with "Workerpool Worker
+   * terminated Unexpectedly", masking the failure we actually want to report.
+   * It has to be idempotent because a WorkerHandler holds a single termination
+   * callback slot: concurrent terminate() calls overwrite each other and every
+   * caller but the last waits on a promise that never settles.
+   */
+  shutdown(): Promise<void> {
+    // workerpool returns its own thenable, so adapt it to a native promise.
+    if (!this.shutdownPromise) this.shutdownPromise = Promise.resolve(this.pool.terminate(false)).then(() => undefined);
+    return this.shutdownPromise;
   }
 
   async init({
@@ -221,11 +243,7 @@ export default class BuildHelper extends WorkerHelper {
   }
 
   async runTarget(buildPath: string, script: string, hash: string, root: string, outputs: Array<string>, buildProject: string, requiredFiles?: string[]): Promise<void> {
-    const execution = await this.execute(buildPath, script, hash, root, outputs, buildProject, requiredFiles);
-    if (execution instanceof Error) {
-      throw Error;
-    }
-    const { output, execTime, metrics } = execution;
+    const { output, execTime, metrics } = await this.execute(buildPath, script, hash, root, outputs, buildProject, requiredFiles);
     if (!isCommandDummy(buildPath, script)) {
       Logger.log(2, this.outputColor, 'Cache does not exist for => ', buildProject, hash);
       this.recordProjectStats(buildProject, { status: 'MISS', execTime, metrics });
@@ -243,6 +261,7 @@ export default class BuildHelper extends WorkerHelper {
   }
 
   async builder(buildProject: string) {
+    if (this.aborted) return;
     try {
       this.totalCount++;
       const root = ConfigHelper.projects[buildProject];
@@ -278,9 +297,7 @@ export default class BuildHelper extends WorkerHelper {
       }
       if (this.noCache) {
         const execution = await this.execute(buildPath, script, '', root, outputs, buildProject, requiredFiles, this.noCache);
-        if (!(execution instanceof Error)) {
-          this.recordProjectStats(buildProject, { status: 'BUILT', execTime: execution.execTime, metrics: execution.metrics });
-        }
+        this.recordProjectStats(buildProject, { status: 'BUILT', execTime: execution.execTime, metrics: execution.metrics });
         await this.buildResolver(buildProject);
         return;
       }
@@ -300,7 +317,6 @@ export default class BuildHelper extends WorkerHelper {
         }
         if (!recoverResponse) {
           const execution = await this.execute(buildPath, script, hash, root, outputs, buildProject, requiredFiles);
-          if (execution instanceof Error) throw execution;
           this.recordProjectStats(buildProject, { status: 'STALE', execTime: execution.execTime, metrics: execution.metrics });
         } else {
           this.recordProjectStats(buildProject, { status: 'HIT', metrics });
@@ -308,11 +324,12 @@ export default class BuildHelper extends WorkerHelper {
       }
       await this.buildResolver(buildProject);
     } catch (error) {
-      if (error instanceof Error) {
-        Logger.log(3, this.outputColor, 'ERR-B1 :: project: ', buildProject, ' error: ', error.message);
-        await this.pool.terminate(true);
-        throw error;
-      } else throw new Error('Builder failed.');
+      const failure = toZenithCommandError(error, { project: buildProject, script: this.command, phase: 'execute' });
+      Logger.log(3, this.outputColor, 'ERR-B1 :: project: ', buildProject, ' error: ', failure.message);
+      if (!this.failure) this.failure = failure;
+      this.aborted = true;
+      await this.shutdown();
+      throw failure;
     }
   }
 
@@ -332,7 +349,7 @@ export default class BuildHelper extends WorkerHelper {
     const stats = this.pool.stats();
     if (!projects.length) {
       if (!stats.pendingTasks && !stats.activeTasks) {
-        void this.pool.terminate();
+        void this.shutdown();
         Logger.log(2, this.outputColor, `Zenith completed command: ${this.command}. ${this.noCache ? '(Cache was not used)' : ''}`);
         if (this.projectStats.size > 0) {
           const statsMode = configManagerInstance.getConfigValue('ZENITH_STATS_MODE');
@@ -367,11 +384,21 @@ export default class BuildHelper extends WorkerHelper {
       }
       return;
     }
-    await Promise.all(projects.map(async eachProject => {
-      if (!this.started.has(eachProject)) {
-        this.started.add(eachProject);
+    // Let every branch settle before rethrowing: a plain Promise.all surfaces
+    // whichever rejection won the race, which is usually pool-shutdown noise
+    // rather than the command failure that actually stopped the run.
+    const settled = await Promise.all(projects.map(async eachProject => {
+      if (this.started.has(eachProject)) return null;
+      this.started.add(eachProject);
+      try {
         await this.builder(eachProject);
+        return null;
+      } catch (error) {
+        return error;
       }
     }));
+    if (this.failure) throw this.failure;
+    const rejection = settled.find(result => result !== null);
+    if (rejection) throw toZenithCommandError(rejection, { script: this.command, phase: 'execute' });
   }
 }

--- a/src/classes/Builder/SingleBuilder.ts
+++ b/src/classes/Builder/SingleBuilder.ts
@@ -1,6 +1,7 @@
 import Logger from '../../utils/logger';
 import BuildHelper from "./BuildHelper";
 import { formatTimeDiff } from '../../utils/functions';
+import { formatFailureBlock } from '../../utils/errors';
 
 export default class SingleBuilder extends BuildHelper {
 
@@ -15,9 +16,6 @@ export default class SingleBuilder extends BuildHelper {
 
   async runManual({cwd, command, hash}: {cwd: string, command: string, hash: string}) {
     const output = await this.executeManual({cwd, command, hash});
-    if (output instanceof Error) {
-      throw output;
-    }
     Logger.log(2, output.output);
   }
 
@@ -26,14 +24,16 @@ export default class SingleBuilder extends BuildHelper {
     try {
       await this.fetchOrRun(hash);
     } catch (err) {
-      Logger.log(2, err);
+      await this.shutdown();
+      // eslint-disable-next-line no-console
+      console.error(formatFailureBlock(err));
       process.exit(1);
     }
     // eslint-disable-next-line no-constant-condition
     while (true) {
       const stats = this.pool.stats();
       if (!stats.activeTasks && !stats.pendingTasks) {
-        void this.pool.terminate();
+        void this.shutdown();
         Logger.log(2, this.outputColor, `Zenith completed command: ${this.command}. ${this.noCache ? '(Cache was not used)' : ''}`);
         Logger.log(2, this.outputColor, `Total of ${this.totalCount} project${this.totalCount === 1 ? ' is' : 's are'} finished.`);
         Logger.log(2, this.outputColor, `Total process took (${formatTimeDiff(process.hrtime(this.startTime))}).`);

--- a/src/classes/WorkerHelper.ts
+++ b/src/classes/WorkerHelper.ts
@@ -1,6 +1,7 @@
 import workerpool from 'workerpool';
 import ConfigHelper from './ConfigHelper';
 import Logger from '../utils/logger';
+import { fromWorkerError } from '../utils/errors';
 import { BuildConfig } from '../types/ConfigTypes';
 import { CacheRecoveryOutput, CommandExecutionOutput } from '../types';
 
@@ -21,37 +22,33 @@ export default class WorkerHelper {
     this.buildConfigJSON = ConfigHelper.buildConfigJSON;
   }
 
-  async execute(buildPath: string, command: string, hash: string, root: string, outputs: Array<string>, projectName: string, requiredFiles: string[] | undefined, noCache = false) : Promise<CommandExecutionOutput | Error> {
+  async execute(buildPath: string, command: string, hash: string, root: string, outputs: Array<string>, projectName: string, requiredFiles: string[] | undefined, noCache = false) : Promise<CommandExecutionOutput> {
     try {
-      const execution =  await this.pool.exec('execute', [buildPath, command, hash, root, outputs, projectName, requiredFiles, noCache], {
+      return await this.pool.exec('execute', [buildPath, command, hash, root, outputs, projectName, requiredFiles, noCache], {
         on: message => Logger.log(3, message)
-      }) as CommandExecutionOutput | Error;
-      if (execution instanceof Error) throw new Error('Executing worker failed');
-      return execution;
-
+      }) as CommandExecutionOutput;
     } catch (error) {
-      if (error instanceof Error) throw error;
-      throw new Error('Executing worker failed');
+      throw fromWorkerError(error, { project: projectName, script: command, phase: 'execute' });
     }
   }
 
-  async executeManual({cwd, command, hash}: {cwd: string, command: string, hash: string}): Promise<{[output: string]: string } | Error> {
+  async executeManual({cwd, command, hash}: {cwd: string, command: string, hash: string}): Promise<{[output: string]: string }> {
     try {
-      const execution = await this.pool.exec('manual', [cwd, command, hash], {
+      return await this.pool.exec('manual', [cwd, command, hash], {
         on: message => Logger.log(3, message)
-      }) as {[output: string]: string} | Error;
-      if (execution instanceof Error) throw new Error('Executing worker failed');
-      return execution;
-
+      }) as {[output: string]: string};
     } catch (error) {
-      if (error instanceof Error) throw error;
-      throw new Error('Executing worker failed');
+      throw fromWorkerError(error, { script: command, cwd, phase: 'manual' });
     }
   }
 
   async anotherJob(hash: string, root: string, output: string, target: string, compareHashes: boolean, logAffected: boolean): Promise<CacheRecoveryOutput> {
-    return await this.pool.exec('anotherJob', [hash, root, output, target, compareHashes, logAffected], {
-      on: message => Logger.log(3, message)
+    try {
+      return await this.pool.exec('anotherJob', [hash, root, output, target, compareHashes, logAffected], {
+        on: message => Logger.log(3, message)
       }) as CacheRecoveryOutput;
+    } catch (error) {
+      throw fromWorkerError(error, { project: root, script: target, phase: 'recover' });
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
 import { run } from "./run";
+import { formatFailureBlock } from "./utils/errors";
 
-void run();
+run().catch((error: unknown) => {
+  // eslint-disable-next-line no-console
+  console.error(formatFailureBlock(error));
+  process.exitCode = 1;
+});

--- a/src/run.ts
+++ b/src/run.ts
@@ -15,8 +15,6 @@ export const run = async () => {
         await RunnerHelper.runWrapper();
     }
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.log('ERR => R-I ::');
     if (error instanceof Error) throw error;
     throw Error(String(error));
   }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,172 @@
+import { ExecError } from '../types/BuildTypes';
+
+export type FailurePhase = 'execute' | 'manual' | 'recover';
+
+export interface FailureContext {
+  project?: string;
+  script?: string;
+  command?: string;
+  cwd?: string;
+  phase: FailurePhase;
+}
+
+/**
+ * Shape a ZenithCommandError takes after crossing the worker boundary. workerpool
+ * copies own enumerable props off the thrown error and rebuilds a plain `Error`
+ * on the other side, so `instanceof` is lost but the fields below survive.
+ */
+export interface SerializedFailure {
+  zenithFailure: true;
+  message: string;
+  stack?: string;
+  project?: string;
+  script?: string;
+  command?: string;
+  cwd?: string;
+  phase: FailurePhase;
+  exitCode?: number;
+  signal?: string | number | null;
+  stdout?: string;
+  stderr?: string;
+}
+
+const toText = (value: unknown): string | undefined => {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'string') return value || undefined;
+  if (Buffer.isBuffer(value)) return value.toString('utf-8') || undefined;
+  return String(value);
+};
+
+/**
+ * `execSync` builds its message as `Command failed: <cmd>\n<stderr>`. The stderr
+ * is reported on its own further down, so drop the duplicate tail.
+ */
+const stripTrailing = (message: string, suffix: string | undefined): string => {
+  if (!suffix) return message.trim();
+  const trimmed = message.trim();
+  return trimmed.endsWith(suffix.trim()) ? trimmed.slice(0, trimmed.length - suffix.trim().length).trim() : trimmed;
+};
+
+export const isExecError = (error: unknown): error is ExecError => (
+  error !== null
+  && typeof error === 'object'
+  && ('stderr' in error || 'stdout' in error)
+  && 'status' in error
+);
+
+const isSerializedFailure = (error: unknown): error is SerializedFailure => (
+  error !== null
+  && typeof error === 'object'
+  && (error as { zenithFailure?: unknown }).zenithFailure === true
+);
+
+export class ZenithCommandError extends Error {
+  project?: string;
+
+  script?: string;
+
+  command?: string;
+
+  cwd?: string;
+
+  phase: FailurePhase;
+
+  exitCode?: number;
+
+  signal?: string | number | null;
+
+  stdout?: string;
+
+  stderr?: string;
+
+  /**
+   * Marks the payload so it can be recognised after workerpool strips the
+   * prototype. Enumerable and own, which is what `convertError` copies.
+   */
+  zenithFailure = true as const;
+
+  constructor(message: string, details: Omit<SerializedFailure, 'zenithFailure' | 'message' | 'stack'>) {
+    super(message);
+    this.name = 'ZenithCommandError';
+    this.project = details.project;
+    this.script = details.script;
+    this.command = details.command;
+    this.cwd = details.cwd;
+    this.phase = details.phase;
+    this.exitCode = details.exitCode;
+    this.signal = details.signal;
+    this.stdout = details.stdout;
+    this.stderr = details.stderr;
+  }
+
+  static fromSerialized(payload: SerializedFailure): ZenithCommandError {
+    const error = new ZenithCommandError(payload.message, payload);
+    if (payload.stack) error.stack = payload.stack;
+    return error;
+  }
+}
+
+/**
+ * Wraps whatever the worker threw into a ZenithCommandError, keeping the child
+ * process' exit code and captured output so the failure can be reported in full.
+ */
+export const toZenithCommandError = (error: unknown, context: FailureContext): ZenithCommandError => {
+  if (error instanceof ZenithCommandError) return error;
+  if (isSerializedFailure(error)) return ZenithCommandError.fromSerialized(error);
+
+  if (isExecError(error)) {
+    const stderr = toText(error.stderr);
+    const failure = new ZenithCommandError(stripTrailing(error.message, stderr), {
+      ...context,
+      exitCode: typeof error.status === 'number' ? error.status : undefined,
+      signal: error.signal ?? null,
+      stdout: toText(error.stdout),
+      stderr
+    });
+    if (error.stack) failure.stack = error.stack;
+    return failure;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  const failure = new ZenithCommandError(message, context);
+  if (error instanceof Error && error.stack) failure.stack = error.stack;
+  return failure;
+};
+
+/** Rehydrates an error that came back through workerpool, tagging it with caller context. */
+export const fromWorkerError = (error: unknown, context: FailureContext): ZenithCommandError => {
+  const failure = toZenithCommandError(error, context);
+  failure.project = failure.project || context.project;
+  failure.script = failure.script || context.script;
+  failure.command = failure.command || context.command;
+  failure.cwd = failure.cwd || context.cwd;
+  return failure;
+};
+
+const PHASE_LABELS: Record<FailurePhase, string> = {
+  execute: 'running target',
+  manual: 'running command',
+  recover: 'recovering cache'
+};
+
+/** Single human-readable block describing why the run stopped. */
+export const formatFailureBlock = (error: unknown): string => {
+  if (!(error instanceof ZenithCommandError) && !isSerializedFailure(error)) {
+    const message = error instanceof Error ? (error.stack || error.message) : String(error);
+    return `Zenith failed: ${message}`;
+  }
+
+  const failure = error instanceof ZenithCommandError ? error : ZenithCommandError.fromSerialized(error);
+  const target = failure.project ? `${failure.project}  (target: ${failure.script || 'unknown'})` : failure.script || 'unknown';
+  const lines = [`Zenith failed: ${target}`, `  phase    : ${PHASE_LABELS[failure.phase]}`];
+  if (failure.command) lines.push(`  command  : ${failure.command}`);
+  if (failure.cwd) lines.push(`  cwd      : ${failure.cwd}`);
+  if (failure.exitCode !== undefined || failure.signal) {
+    lines.push(`  exit code: ${failure.exitCode ?? 'unknown'}   signal: ${failure.signal || 'none'}`);
+  }
+  lines.push(`  error    : ${failure.message}`);
+  if (failure.stdout) lines.push('  --- stdout ---', failure.stdout);
+  if (failure.stderr) lines.push('  --- stderr ---', failure.stderr);
+  if (!failure.stdout && !failure.stderr && failure.stack) lines.push('  --- stack ---', failure.stack);
+  return lines.join('\n');
+};

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -11,7 +11,13 @@ class Logger {
   }
 
   log(level: number, color?: string | unknown, ...args: Array<unknown>) {
-    if (this.logLevel >= level && typeof color === 'string') console.log(`${color}${args.join(' ')}`, "\x1b[0m");
+    if (this.logLevel < level) return;
+    // Callers may skip the color argument and pass a value straight through
+    // (e.g. an Error). Treat a non-string first argument as part of the message
+    // instead of dropping the whole line.
+    const prefix = typeof color === 'string' ? color : '';
+    const rest: Array<unknown> = typeof color === 'string' ? args : [color, ...args];
+    console.log(`${prefix}${rest.join(' ')}`, "\x1b[0m");
   }
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2,19 +2,19 @@ import workerpool from 'workerpool';
 import { execSync } from 'child_process';
 import CacherFactory from './classes/Cache/CacheFactory';
 import { Readable } from 'stream';
-import Logger from './utils/logger';
 import { ROOT_PATH } from './utils/constants';
 import { readableToBuffer } from './utils/functions';
+import { toZenithCommandError } from './utils/errors';
 import { hrtimeToMs } from './utils/time';
 import { metricsCollector } from './metrics/MetricsCollector';
 import { recordOutputStats } from './classes/Cache/metrics/recordOutputStats';
 import { configManagerInstance } from './config';
 import ConfigHelperInstance from './classes/ConfigHelper';
-import { ExecError } from './types/BuildTypes';
 import HybridCacher from './classes/Cache/HybridCacher';
 import { CommandExecutionOutput, CacheRecoveryOutput } from './types';
 
-const execute = async (buildPath: string, targetCommand: string, hash: string, root: string, outputs: Array<string>, projectName: string, requiredFiles: string[] | undefined, noCache = false): Promise<CommandExecutionOutput | Error> => {
+const execute = async (buildPath: string, targetCommand: string, hash: string, root: string, outputs: Array<string>, projectName: string, requiredFiles: string[] | undefined, noCache = false): Promise<CommandExecutionOutput> => {
+  const shellCommand = `pnpm --filter ${projectName} ${targetCommand}`;
   try {
     metricsCollector.reset();
     const cacher = CacherFactory.getCacher();
@@ -23,7 +23,7 @@ const execute = async (buildPath: string, targetCommand: string, hash: string, r
     if (project === undefined) throw new Error('Could not read build path in execute method!');
     workerpool.workerEmit(`Running ${targetCommand} command for => ${project}`);
     const executeStart = process.hrtime();
-    const commandOutput = execSync(`pnpm --filter ${projectName} ${targetCommand}`, { cwd: ROOT_PATH, encoding: 'utf-8' });
+    const commandOutput = execSync(shellCommand, { cwd: ROOT_PATH, encoding: 'utf-8' });
     const execTime = process.hrtime(executeStart);
     await recordOutputStats(root, outputs, commandOutput);
     if (noCache) return { output: commandOutput, execTime, metrics: metricsCollector.snapshot() };
@@ -42,13 +42,9 @@ const execute = async (buildPath: string, targetCommand: string, hash: string, r
     return { output: commandOutput, execTime, cacheTime, metrics: metricsCollector.snapshot() };
   } catch (error) {
     if (ConfigHelperInstance.onFail) ConfigHelperInstance.onFail(targetCommand, { error, hash, root, outputs, projectName, requiredFiles });
-    if (error && typeof error === 'object' && 'stderr' in error) {
-      const execErr = error as ExecError;
-      Logger.log(2, 'ERR-W-E-1 :: output => ', execErr.stdout);
-      throw execErr;
-    }
-    Logger.log(2, 'ERR-W-E-3 :: output => ', error);
-    return new Error(String(error));
+    throw toZenithCommandError(error, {
+      project: projectName, script: targetCommand, command: shellCommand, cwd: ROOT_PATH, phase: 'execute'
+    });
   }
 };
 
@@ -76,20 +72,17 @@ const anotherJob = async (hash: string, root: string, output: string, target: st
     workerpool.workerEmit(outputHash === remoteHash ? `Hash hit for ${root}` : `Hashes mismatched for ${root},  ${outputHash} !== ${remoteHash}`);
     return { result: remoteHash === outputHash, time: process.hrtime(start), metrics: metricsCollector.snapshot() };
   } catch (error) {
-    if (error && typeof error === 'object' && 'stderr' in error) {
-      const execErr = error as ExecError;
-      Logger.log(2, 'ERR-W-A :: output => ', execErr.stderr);
-      throw execErr;
-    }
-    Logger.log(2, 'ERR-W-A :: output => ', error);
-    throw new Error(String(error));
+    throw toZenithCommandError(error, {
+      project: root, script: target, cwd: ROOT_PATH, phase: 'recover'
+    });
   }
 };
 
-const manual = async (cwd: string, command: string, hash: string) => {
+const manual = async (cwd: string, command: string, hash: string): Promise<{ output: string }> => {
+  const shellCommand = `pnpm run ${command}`;
   try {
     const cacher = CacherFactory.getCacher();
-    const output = execSync(`pnpm run ${command}`, { cwd, encoding: 'utf-8'});
+    const output = execSync(shellCommand, { cwd, encoding: 'utf-8'});
     await cacher.cache(hash, 'root', 'stdout', command, output, []);
     await cacher.sendOutputHash(hash, 'root', output, command);
     if (!configManagerInstance.getConfigValue('ZENITH_READ_ONLY')) {
@@ -97,13 +90,9 @@ const manual = async (cwd: string, command: string, hash: string) => {
     }
     return { output };
   } catch (error) {
-    if (error && typeof error === 'object' && 'stderr' in error) {
-      const execErr = error as ExecError;
-      Logger.log(2, 'ERR-W-A :: output => ', execErr.stdout);
-      throw execErr;
-    }
-    Logger.log(2, 'ERR-W-A :: output => ', error);
-    return new Error(String(error));
+    throw toZenithCommandError(error, {
+      script: command, command: shellCommand, cwd, phase: 'manual'
+    });
   }
 };
 

--- a/tests/WorkerFailure.spec.js
+++ b/tests/WorkerFailure.spec.js
@@ -1,0 +1,160 @@
+import path from 'path';
+import os from 'os';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { ZenithCommandError, toZenithCommandError, fromWorkerError, formatFailureBlock } from '../build/utils/errors';
+import WorkerHelper from '../build/classes/WorkerHelper';
+import BuildHelper from '../build/classes/Builder/BuildHelper';
+
+/** workerpool/src/worker.js — how a thrown error is packed before postMessage. */
+const convertError = (error) => Object.getOwnPropertyNames(error).reduce((product, name) => (
+    Object.defineProperty(product, name, { value: error[name], enumerable: true })
+), {});
+
+/** workerpool/src/WorkerHandler.js — how the parent unpacks it. Prototype is lost here. */
+const objectToError = (obj) => {
+    const temp = new Error('');
+    Object.keys(obj).forEach(key => { temp[key] = obj[key]; });
+    return temp;
+};
+
+const makeExecError = () => {
+    const error = new Error('Command failed: pnpm --filter app1 build');
+    error.status = 2;
+    error.signal = null;
+    error.pid = 1234;
+    error.output = [null, 'TS2304: Cannot find name foo\n', ''];
+    error.stdout = 'TS2304: Cannot find name foo\n';
+    error.stderr = 'compilation failed\n';
+    return error;
+};
+
+describe('Worker failure reporting', () => {
+    test('toZenithCommandError keeps exit code and captured output of a failed command', () => {
+        const failure = toZenithCommandError(makeExecError(), {
+            project: 'app1', script: 'build', command: 'pnpm --filter app1 build', cwd: '/repo', phase: 'execute'
+        });
+
+        expect(failure).toBeInstanceOf(ZenithCommandError);
+        expect(failure.project).toBe('app1');
+        expect(failure.exitCode).toBe(2);
+        expect(failure.stdout).toContain('TS2304: Cannot find name foo');
+        expect(failure.stderr).toContain('compilation failed');
+    });
+
+    test('formatFailureBlock reports project, command, exit code and both streams', () => {
+        const block = formatFailureBlock(toZenithCommandError(makeExecError(), {
+            project: 'app1', script: 'build', command: 'pnpm --filter app1 build', cwd: '/repo', phase: 'execute'
+        }));
+
+        expect(block).toContain('Zenith failed: app1');
+        expect(block).toContain('(target: build)');
+        expect(block).toContain('pnpm --filter app1 build');
+        expect(block).toContain('exit code: 2');
+        expect(block).toContain('--- stdout ---');
+        expect(block).toContain('TS2304: Cannot find name foo');
+        expect(block).toContain('--- stderr ---');
+        expect(block).toContain('compilation failed');
+    });
+
+    test('failure details survive the workerpool serialization round trip', () => {
+        const thrown = toZenithCommandError(makeExecError(), {
+            project: 'app1', script: 'build', command: 'pnpm --filter app1 build', cwd: '/repo', phase: 'execute'
+        });
+
+        // Prototype is gone after the round trip, so instanceof cannot be relied on.
+        const received = objectToError(convertError(thrown));
+        expect(received).not.toBeInstanceOf(ZenithCommandError);
+
+        const rehydrated = fromWorkerError(received, { project: 'app1', script: 'build', phase: 'execute' });
+        expect(rehydrated).toBeInstanceOf(ZenithCommandError);
+        expect(rehydrated.message).toBe('Command failed: pnpm --filter app1 build');
+        expect(rehydrated.exitCode).toBe(2);
+        expect(rehydrated.stdout).toContain('TS2304: Cannot find name foo');
+        expect(rehydrated.stderr).toContain('compilation failed');
+        expect(formatFailureBlock(rehydrated)).toContain('exit code: 2');
+    });
+
+    test('formatFailureBlock falls back to the stack for a plain error', () => {
+        expect(formatFailureBlock(new Error('something broke'))).toContain('something broke');
+        expect(formatFailureBlock('not an error')).toBe('Zenith failed: not an error');
+    });
+
+    describe('against a real worker thread', () => {
+        // Self-contained fixture: running pnpm inside tests/__mocks__/mockRepo would
+        // trip its workspace dependency check, which needs the network.
+        let fixture;
+
+        beforeAll(() => {
+            fixture = mkdtempSync(path.join(os.tmpdir(), 'zenith-failure-fixture-'));
+            // Both scripts exit non-zero on purpose: a successful run would cache its
+            // output, and a worker thread does not see jest's sandboxed process.env,
+            // so LOCAL_CACHE_PATH cannot redirect those writes out of the repo.
+            writeFileSync(path.join(fixture, 'package.json'), JSON.stringify({
+                name: 'failure-fixture',
+                version: '1.0.0',
+                scripts: {
+                    boom: 'node -e "console.log(\'TS2304: Cannot find name foo\'); process.exit(3)"',
+                    slow: 'node -e "setTimeout(() => process.exit(1), 1500)"'
+                }
+            }));
+        });
+
+        afterAll(() => {
+            rmSync(fixture, { recursive: true, force: true });
+        });
+
+        test('a failing command surfaces its own output, not a worker termination message', async () => {
+            const helper = new WorkerHelper('boom', '1');
+
+            try {
+                const failure = await helper.executeManual({ cwd: fixture, command: 'boom', hash: 'no-hash' })
+                    .then(() => null, error => error);
+
+                expect(failure).toMatchObject({
+                    name: 'ZenithCommandError',
+                    phase: 'manual',
+                    exitCode: 3,
+                    command: 'pnpm run boom'
+                });
+                expect(failure.stdout).toContain('TS2304: Cannot find name foo');
+
+                const block = formatFailureBlock(failure);
+                expect(block).toContain('exit code: 3');
+                expect(block).toContain('TS2304: Cannot find name foo');
+                expect(block).not.toContain('Workerpool Worker terminated Unexpectedly');
+                expect(block).not.toContain('Executing worker failed');
+            } finally {
+                await helper.pool.terminate(true);
+            }
+        }, 60000);
+
+        // A WorkerHandler holds a single termination callback slot, so concurrent
+        // graceful terminates overwrite each other and every caller but the last
+        // waits on a promise that never settles. Every failing project calls
+        // shutdown, so without memoization the whole run hangs and exits silently.
+        test('concurrent shutdowns all settle while workers are busy', async () => {
+            const helper = new BuildHelper('slow', '2', false);
+
+            try {
+                const busy = [
+                    helper.executeManual({ cwd: fixture, command: 'slow', hash: 'hash-a' }).catch(() => null),
+                    helper.executeManual({ cwd: fixture, command: 'slow', hash: 'hash-b' }).catch(() => null)
+                ];
+
+                const shutdowns = [helper.shutdown(), helper.shutdown(), helper.shutdown()];
+
+                let timer;
+                const outcome = await Promise.race([
+                    Promise.all(shutdowns).then(() => 'settled'),
+                    new Promise(resolve => { timer = setTimeout(() => resolve('hung'), 15000); })
+                ]);
+                clearTimeout(timer);
+                expect(outcome).toBe('settled');
+                expect(shutdowns[1]).toBe(shutdowns[0]);
+                await Promise.all(busy);
+            } finally {
+                await helper.pool.terminate(true);
+            }
+        }, 60000);
+    });
+});


### PR DESCRIPTION
Failures now surface as a structured ZenithCommandError with project, command, exit code, and full stdout/stderr. Pool shutdown is graceful and memoized so sibling tasks no longer mask the actual error.

chore: 3.7.0